### PR TITLE
fix(rbac): handle preexisting policies and grouping policies

### DIFF
--- a/plugins/rbac-backend/src/service/enforcer-delegate.ts
+++ b/plugins/rbac-backend/src/service/enforcer-delegate.ts
@@ -64,9 +64,9 @@ export class EnforcerDelegate {
       if (!ok) {
         throw new Error(`failed to create policy ${policyToString(policy)}`);
       }
-      addMetadataTrx.commit();
+      await addMetadataTrx.commit();
     } catch (err) {
-      addMetadataTrx.rollback();
+      await addMetadataTrx.rollback();
       throw err;
     }
   }
@@ -87,9 +87,9 @@ export class EnforcerDelegate {
           `Failed to store policies ${policiesToString(policies)}`,
         );
       }
-      addMetadataTrx.commit();
+      await addMetadataTrx.commit();
     } catch (err) {
-      addMetadataTrx.rollback();
+      await addMetadataTrx.rollback();
       throw err;
     }
   }
@@ -107,9 +107,9 @@ export class EnforcerDelegate {
       if (!ok) {
         throw new Error(`failed to create policy ${policyToString(policy)}`);
       }
-      addMetadataTrx.commit();
+      await addMetadataTrx.commit();
     } catch (err) {
-      addMetadataTrx.rollback();
+      await addMetadataTrx.rollback();
       throw err;
     }
   }
@@ -134,9 +134,9 @@ export class EnforcerDelegate {
           `Failed to store policies ${policiesToString(policies)}`,
         );
       }
-      addMetadataTrx.commit();
+      await addMetadataTrx.commit();
     } catch (err) {
-      addMetadataTrx.rollback();
+      await addMetadataTrx.rollback();
       throw err;
     }
   }
@@ -152,9 +152,9 @@ export class EnforcerDelegate {
       if (!ok) {
         throw new Error(`fail to delete policy ${policy}`);
       }
-      rmMetadataTrx.commit();
+      await rmMetadataTrx.commit();
     } catch (err) {
-      rmMetadataTrx.rollback(err);
+      await rmMetadataTrx.rollback(err);
       throw err;
     }
   }
@@ -176,9 +176,9 @@ export class EnforcerDelegate {
           `Failed to delete policies ${policiesToString(policies)}`,
         );
       }
-      rmMetadataTrx.commit();
+      await rmMetadataTrx.commit();
     } catch (err) {
-      rmMetadataTrx.rollback(err);
+      await rmMetadataTrx.rollback(err);
       throw err;
     }
   }
@@ -196,9 +196,9 @@ export class EnforcerDelegate {
       if (!ok) {
         throw new Error(`Failed to delete policy ${policyToString(policy)}`);
       }
-      rmMetadataTrx.commit();
+      await rmMetadataTrx.commit();
     } catch (err) {
-      rmMetadataTrx.rollback(err);
+      await rmMetadataTrx.rollback(err);
       throw err;
     }
   }
@@ -219,9 +219,9 @@ export class EnforcerDelegate {
           `Failed to delete grouping policies: ${policiesToString(policies)}`,
         );
       }
-      rmMetadataTrx.commit();
+      await rmMetadataTrx.commit();
     } catch (err) {
-      rmMetadataTrx.rollback(err);
+      await rmMetadataTrx.rollback(err);
       throw err;
     }
   }
@@ -264,5 +264,27 @@ export class EnforcerDelegate {
     source: Source,
   ): Promise<PermissionPolicyMetadataDao[]> {
     return await this.metadataStorage.findPolicyMetadataBySource(source);
+  }
+
+  async getPoliciesWithoutSource(): Promise<string[][]> {
+    const policiesWithoutSource: string[][] = [];
+    const allPolicies = await this.enforcer.getPolicy();
+    for (const policy of allPolicies) {
+      const sourcePolicy =
+        await this.metadataStorage.findPolicyMetadata(policy);
+      if (!sourcePolicy) {
+        policiesWithoutSource.push(policy);
+      }
+    }
+    return policiesWithoutSource;
+  }
+
+  async migratePreexistingPolicies(enforcer: Enforcer): Promise<void> {
+    const policies = await this.getPoliciesWithoutSource();
+
+    for (const policy of policies) {
+      await enforcer.removePolicy(...policy);
+      await this.addPolicy(policy, 'legacy');
+    }
   }
 }

--- a/plugins/rbac-backend/src/service/policy-builder.ts
+++ b/plugins/rbac-backend/src/service/policy-builder.ts
@@ -92,6 +92,8 @@ export class PolicyBuilder {
       knex,
     );
 
+    await enforcerDelegate.migratePreexistingPolicies(enf);
+
     const options: RouterOptions = {
       config: env.config,
       logger: env.logger,

--- a/plugins/rbac-backend/src/service/policy-builder.ts
+++ b/plugins/rbac-backend/src/service/policy-builder.ts
@@ -89,6 +89,7 @@ export class PolicyBuilder {
     const enforcerDelegate = new EnforcerDelegate(
       enf,
       policyMetadataStorage,
+      roleMetadataStorage,
       knex,
     );
 

--- a/plugins/rbac-common/src/types.ts
+++ b/plugins/rbac-common/src/types.ts
@@ -1,7 +1,8 @@
 export type Source =
   | 'rest' // created via REST API
   | 'csv-file' // created via policies-csv-file with defined path in the application configuration
-  | 'configuration'; // created from application configuration
+  | 'configuration' // created from application configuration
+  | 'legacy'; // preexisting policies
 
 export type RoleSource = Source | 'default'; // hard coded in the plugin code
 


### PR DESCRIPTION
Here is the PR for handling the preexisting policies and grouping policies. I have done some manual testing of it, just double check behind me in case I missed anything.

All this really does is adds the preexisting policies and group policies to their respective tables with the 'legacy' source. I didn't implement any additional checks for the 'REST API'. 

About what we talked about earlier, I think the following should be fine:
'legacy': should be updated by anything,
'config': should be only updated through the config (maybe the REST API?)
'csv': should only be updated through the csv file
'rest': should only be updated through the REST API
'default': saving for a special case, possibly to do with super admins

Let me know what you think.