### PR TITLE
fix(rbac): add the ability to update legacy policies

### DIFF
--- a/plugins/rbac-backend/src/helper.ts
+++ b/plugins/rbac-backend/src/helper.ts
@@ -1,3 +1,9 @@
+import { difference } from 'lodash';
+
+import { Source } from '@janus-idp/backstage-plugin-rbac-common';
+
+import { EnforcerDelegate } from './service/enforcer-delegate';
+
 export function policyToString(policy: string[]): string {
   return `[${policy.join(', ')}]`;
 }
@@ -11,4 +17,19 @@ export function policiesToString(policies: string[][]): string {
 
 export function metadataStringToPolicy(policy: string): string[] {
   return policy.replace('[', '').replace(']', '').split(', ');
+}
+
+export async function removeTheDifference(
+  originalGroup: string[],
+  addedGroup: string[],
+  source: Source,
+  roleName: string,
+  enf: EnforcerDelegate,
+): Promise<void> {
+  const missing = difference(originalGroup.sort(), addedGroup.sort());
+
+  missing.forEach(async name => {
+    const role = [name, roleName];
+    await enf.removeGroupingPolicy(role, source, true);
+  });
 }

--- a/plugins/rbac-backend/src/service/enforcer-delegate.ts
+++ b/plugins/rbac-backend/src/service/enforcer-delegate.ts
@@ -12,12 +12,14 @@ import {
   PermissionPolicyMetadataDao,
   PolicyMetadataStorage,
 } from '../database/policy-metadata-storage';
+import { RoleMetadataStorage } from '../database/role-metadata';
 import { policiesToString, policyToString } from '../helper';
 
 export class EnforcerDelegate {
   constructor(
     private readonly enforcer: Enforcer,
     private readonly policyMetadataStorage: PolicyMetadataStorage,
+    private readonly roleMetadataStorage: RoleMetadataStorage,
     private readonly knex: Knex,
   ) {}
 
@@ -51,50 +53,7 @@ export class EnforcerDelegate {
     return await this.enforcer.getFilteredGroupingPolicy(fieldIndex, ...filter);
   }
 
-  async addPolicy(policy: string[], source: Source): Promise<void> {
-    const addMetadataTrx = await this.knex.transaction();
-
-    try {
-      await this.policyMetadataStorage.createPolicyMetadata(
-        source,
-        policy,
-        addMetadataTrx,
-      );
-      const ok = await this.enforcer.addPolicy(...policy);
-      if (!ok) {
-        throw new Error(`failed to create policy ${policyToString(policy)}`);
-      }
-      await addMetadataTrx.commit();
-    } catch (err) {
-      await addMetadataTrx.rollback(err);
-      throw err;
-    }
-  }
-
-  async addPolicies(policies: string[][], source: Source): Promise<void> {
-    const addMetadataTrx = await this.knex.transaction();
-    try {
-      for (const policy of policies) {
-        await this.policyMetadataStorage.createPolicyMetadata(
-          source,
-          policy,
-          addMetadataTrx,
-        );
-      }
-      const ok = this.enforcer.addPolicies(policies);
-      if (!ok) {
-        throw new Error(
-          `Failed to store policies ${policiesToString(policies)}`,
-        );
-      }
-      await addMetadataTrx.commit();
-    } catch (err) {
-      await addMetadataTrx.rollback(err);
-      throw err;
-    }
-  }
-
-  async addGroupingPolicy(
+  async addPolicy(
     policy: string[],
     source: Source,
     externalTrx?: Knex.Transaction,
@@ -107,6 +66,82 @@ export class EnforcerDelegate {
         policy,
         trx,
       );
+      const ok = await this.enforcer.addPolicy(...policy);
+      if (!ok) {
+        throw new Error(`failed to create policy ${policyToString(policy)}`);
+      }
+      if (!externalTrx) {
+        await trx.commit();
+      }
+    } catch (err) {
+      if (!externalTrx) {
+        await trx.rollback(err);
+      }
+      throw err;
+    }
+  }
+
+  async addPolicies(
+    policies: string[][],
+    source: Source,
+    externalTrx: Knex.Transaction,
+  ): Promise<void> {
+    const trx = externalTrx || (await this.knex.transaction());
+    try {
+      for (const policy of policies) {
+        await this.policyMetadataStorage.createPolicyMetadata(
+          source,
+          policy,
+          trx,
+        );
+      }
+      const ok = this.enforcer.addPolicies(policies);
+      if (!ok) {
+        throw new Error(
+          `Failed to store policies ${policiesToString(policies)}`,
+        );
+      }
+      if (!externalTrx) {
+        await trx.commit();
+      }
+    } catch (err) {
+      if (!externalTrx) {
+        await trx.rollback(err);
+      }
+      throw err;
+    }
+  }
+
+  async addGroupingPolicy(
+    policy: string[],
+    source: Source,
+    externalTrx?: Knex.Transaction,
+    isUpdate?: boolean,
+  ): Promise<void> {
+    const entityRef = policy[1];
+    let metadata;
+
+    if (entityRef.startsWith(`role:`)) {
+      metadata = await this.roleMetadataStorage.findRoleMetadata(entityRef);
+    }
+
+    const trx = externalTrx || (await this.knex.transaction());
+
+    try {
+      await this.policyMetadataStorage.createPolicyMetadata(
+        source,
+        policy,
+        trx,
+      );
+
+      if (!metadata && !isUpdate) {
+        await this.roleMetadataStorage.createRoleMetadata(
+          { source },
+          entityRef,
+          trx,
+        );
+      }
+
       const ok = await this.enforcer.addGroupingPolicy(...policy);
       if (!ok) {
         throw new Error(`failed to create policy ${policyToString(policy)}`);
@@ -126,18 +161,33 @@ export class EnforcerDelegate {
     policies: string[][],
     source: Source,
     externalTrx?: Knex.Transaction,
+    isUpdate?: boolean,
   ): Promise<void> {
     const trx = externalTrx || (await this.knex.transaction());
 
     try {
       for (const policy of policies) {
+        const entityRef = policy[1];
+        let metadata;
+
+        if (entityRef.startsWith(`role:`)) {
+          metadata = await this.roleMetadataStorage.findRoleMetadata(entityRef);
+        }
+
         await this.policyMetadataStorage.createPolicyMetadata(
           source,
           policy,
           trx,
         );
-      }
 
+        if (!metadata && !isUpdate) {
+          await this.roleMetadataStorage.createRoleMetadata(
+            { source },
+            entityRef,
+            trx,
+          );
+        }
+      }
       const ok = await this.enforcer.addGroupingPolicies(policies);
       if (!ok) {
         throw new Error(
@@ -156,32 +206,103 @@ export class EnforcerDelegate {
     }
   }
 
-  async removePolicy(policy: string[], allowToDeleteCSVFilePolicy?: boolean) {
-    const rmMetadataTrx = await this.knex.transaction();
+  async updateGroupingPolicies(
+    oldRole: string[][],
+    newRole: string[][],
+    source: Source,
+    allowToDeleteCSVFilePolicy?: boolean,
+    externalTrx?: Knex.Transaction,
+  ): Promise<void> {
+    const trx = externalTrx || (await this.knex.transaction());
+    const newRoleName = newRole.at(0)?.at(1)!;
+    const oldRoleName = oldRole.at(0)?.at(1)!;
+    try {
+      await this.roleMetadataStorage.updateRoleMetadata(
+        { source: source, roleEntityRef: newRoleName },
+        oldRoleName,
+        trx,
+      );
+      await this.removeGroupingPolicies(
+        oldRole,
+        source,
+        allowToDeleteCSVFilePolicy,
+        true,
+        trx,
+      );
+      await this.addGroupingPolicies(newRole, source, trx, true);
+      if (!externalTrx) {
+        await trx.commit();
+      }
+    } catch (err) {
+      if (!externalTrx) {
+        await trx.rollback(err);
+      }
+      throw err;
+    }
+  }
+
+  async updatePolicies(
+    oldPolicies: string[][],
+    newPolicies: string[][],
+    source: Source,
+    allowToDeleteCSVFilePolicy?: boolean,
+    externalTrx?: Knex.Transaction,
+  ): Promise<void> {
+    const trx = externalTrx || (await this.knex.transaction());
+
+    try {
+      await this.removePolicies(
+        oldPolicies,
+        source,
+        allowToDeleteCSVFilePolicy,
+        trx,
+      );
+      await this.addPolicies(newPolicies, source, trx);
+      if (!externalTrx) {
+        await trx.commit();
+      }
+    } catch (err) {
+      if (!externalTrx) {
+        await trx.rollback(err);
+      }
+      throw err;
+    }
+  }
+
+  async removePolicy(
+    policy: string[],
+    source: Source,
+    allowToDeleteCSVFilePolicy?: boolean,
+    externalTrx?: Knex.Transaction,
+  ) {
+    const trx = externalTrx || (await this.knex.transaction());
 
     try {
       await this.checkIfPolicyModifiable(
         policy,
-        rmMetadataTrx,
+        source,
+        trx,
         allowToDeleteCSVFilePolicy,
       );
-      await this.policyMetadataStorage.removePolicyMetadata(
-        policy,
-        rmMetadataTrx,
-      );
+      await this.policyMetadataStorage.removePolicyMetadata(policy, trx);
       const ok = await this.enforcer.removePolicy(...policy);
       if (!ok) {
         throw new Error(`fail to delete policy ${policy}`);
       }
-      await rmMetadataTrx.commit();
+      if (!externalTrx) {
+        await trx.commit();
+      }
     } catch (err) {
-      await rmMetadataTrx.rollback(err);
+      if (!externalTrx) {
+        await trx.rollback(err);
+      }
       throw err;
     }
   }
 
   async removePolicies(
     policies: string[][],
+    source: Source,
     allowToDeleCSVFilePolicy?: boolean,
     externalTrx?: Knex.Transaction,
   ): Promise<void> {
@@ -191,6 +312,7 @@ export class EnforcerDelegate {
       for (const policy of policies) {
         await this.checkIfPolicyModifiable(
           policy,
+          source,
           trx,
           allowToDeleCSVFilePolicy,
         );
@@ -216,44 +338,60 @@ export class EnforcerDelegate {
 
   async removeGroupingPolicy(
     policy: string[],
+    source: Source,
+    isUpdate?: boolean,
     allowToDeleCSVFilePolicy?: boolean,
-  ) {
-    const rmMetadataTrx = await this.knex.transaction();
+    externalTrx?: Knex.Transaction,
+  ): Promise<void> {
+    const trx = externalTrx || (await this.knex.transaction());
+    const roleEntity = policy[1];
 
     try {
       await this.checkIfPolicyModifiable(
         policy,
-        rmMetadataTrx,
+        source,
+        trx,
         allowToDeleCSVFilePolicy,
       );
-      await this.policyMetadataStorage.removePolicyMetadata(
-        policy,
-        rmMetadataTrx,
-      );
+      await this.policyMetadataStorage.removePolicyMetadata(policy, trx);
+      if (!isUpdate) {
+        await this.roleMetadataStorage.removeRoleMetadata(roleEntity, trx);
+      }
       const ok = await this.enforcer.removeGroupingPolicy(...policy);
       if (!ok) {
         throw new Error(`Failed to delete policy ${policyToString(policy)}`);
       }
-      await rmMetadataTrx.commit();
+      if (!externalTrx) {
+        await trx.commit();
+      }
     } catch (err) {
-      await rmMetadataTrx.rollback(err);
+      if (!externalTrx) {
+        await trx.rollback(err);
+      }
       throw err;
     }
   }
 
   async removeGroupingPolicies(
     policies: string[][],
+    source: Source,
     allowToDeleteCSVFilePolicy?: boolean,
+    isUpdate?: boolean,
     externalTrx?: Knex.Transaction,
   ): Promise<void> {
     const trx = externalTrx || (await this.knex.transaction());
     try {
       for (const policy of policies) {
+        const roleEntity = policy[1];
         await this.checkIfPolicyModifiable(
           policy,
+          source,
           trx,
           allowToDeleteCSVFilePolicy,
         );
+        if (!isUpdate) {
+          await this.roleMetadataStorage.removeRoleMetadata(roleEntity, trx);
+        }
         await this.policyMetadataStorage.removePolicyMetadata(policy, trx);
       }
 
@@ -275,6 +413,103 @@ export class EnforcerDelegate {
     }
   }
 
+  async addOrUpdatePolicy(
+    policy: string[],
+    source: Source,
+    isCSV: boolean,
+    externalTrx?: Knex.Transaction,
+  ): Promise<void> {
+    const trx = externalTrx || (await this.knex.transaction());
+    try {
+      if (!(await this.enforcer.hasPolicy(...policy))) {
+        await this.addPolicy(policy, source, trx);
+      } else if (await this.hasFilteredPolicyMetadata(policy, 'legacy', trx)) {
+        await this.removePolicy(policy, source, isCSV, trx);
+        await this.addPolicy(policy, source, trx);
+      }
+      if (!externalTrx) {
+        await trx.commit();
+      }
+    } catch (err) {
+      if (!externalTrx) {
+        await trx.rollback(err);
+      }
+      throw err;
+    }
+  }
+
+  async addOrUpdateGroupingPolicy(
+    groupPolicy: string[],
+    source: Source,
+    isCSV?: boolean,
+    externalTrx?: Knex.Transaction,
+  ): Promise<void> {
+    const trx = externalTrx || (await this.knex.transaction());
+    try {
+      if (!(await this.hasGroupingPolicy(...groupPolicy))) {
+        await this.addGroupingPolicy(groupPolicy, source, trx);
+      } else if (
+        await this.hasFilteredPolicyMetadata(groupPolicy, 'legacy', trx)
+      ) {
+        await this.roleMetadataStorage.updateRoleMetadata(
+          { source: source, roleEntityRef: groupPolicy.at(1)! },
+          groupPolicy.at(1)!,
+          trx,
+        );
+        await this.removeGroupingPolicy(groupPolicy, source, true, isCSV, trx);
+        await this.addGroupingPolicy(groupPolicy, source, trx, true);
+      }
+      if (!externalTrx) {
+        await trx.commit();
+      }
+    } catch (err) {
+      if (!externalTrx) {
+        await trx.rollback(err);
+      }
+      throw err;
+    }
+  }
+
+  async addOrUpdateGroupingPolicies(
+    groupPolicies: string[][],
+    source: Source,
+    isCSV?: boolean,
+    externalTrx?: Knex.Transaction,
+  ): Promise<void> {
+    const trx = externalTrx || (await this.knex.transaction());
+    try {
+      for (const groupPolicy of groupPolicies) {
+        if (!(await this.hasGroupingPolicy(...groupPolicy))) {
+          await this.addGroupingPolicy(groupPolicy, source, trx);
+        } else if (
+          await this.hasFilteredPolicyMetadata(groupPolicy, 'legacy', trx)
+        ) {
+          await this.roleMetadataStorage.updateRoleMetadata(
+            { source: source, roleEntityRef: groupPolicy.at(1)! },
+            groupPolicy.at(1)!,
+            trx,
+          );
+          await this.removeGroupingPolicy(
+            groupPolicy,
+            source,
+            true,
+            isCSV,
+            trx,
+          );
+          await this.addGroupingPolicy(groupPolicy, source, trx, true);
+        }
+      }
+      if (!externalTrx) {
+        await trx.commit();
+      }
+    } catch (err) {
+      if (!externalTrx) {
+        await trx.rollback(err);
+      }
+      throw err;
+    }
+  }
+
   async enforce(
     entityRef: string,
     resourceType: string,
@@ -283,7 +518,7 @@ export class EnforcerDelegate {
     return await this.enforcer.enforce(entityRef, resourceType, action);
   }
 
-  async getPolicyMetadata(policy: string[]): Promise<PermissionPolicyMetadata> {
+  async getMetadata(policy: string[]): Promise<PermissionPolicyMetadata> {
     const metadata =
       await this.policyMetadataStorage.findPolicyMetadata(policy);
     if (!metadata) {
@@ -294,6 +529,7 @@ export class EnforcerDelegate {
 
   private async checkIfPolicyModifiable(
     policy: string[],
+    policySource: Source,
     trx: Knex.Transaction,
     allowToModifyCSVFilePolicy?: boolean,
   ) {
@@ -313,7 +549,10 @@ export class EnforcerDelegate {
         )}' can be modified or deleted only with help of 'policies-csv-file'`,
       );
     }
-    if (metadata?.source === 'configuration') {
+    if (
+      metadata?.source === 'configuration' &&
+      policySource !== 'configuration'
+    ) {
       throw new Error(
         `Error: Attempted to modify an immutable pre-defined policy '${policyToString(
           policy,
@@ -329,5 +568,22 @@ export class EnforcerDelegate {
     source: Source,
   ): Promise<PermissionPolicyMetadataDao[]> {
     return await this.policyMetadataStorage.findPolicyMetadataBySource(source);
+  }
+
+  async hasFilteredPolicyMetadata(
+    policy: string[],
+    source: Source,
+    externalTrx?: Knex.Transaction,
+  ): Promise<Boolean> {
+    const metadata = await this.policyMetadataStorage.findPolicyMetadata(
+      policy,
+      externalTrx,
+    );
+
+    if (metadata?.source === source) {
+      return true;
+    }
+
+    return false;
   }
 }

--- a/plugins/rbac-backend/src/service/permission-policy.test.ts
+++ b/plugins/rbac-backend/src/service/permission-policy.test.ts
@@ -12,6 +12,7 @@ import { PolicyQuery } from '@backstage/plugin-permission-node';
 import {
   Adapter,
   Enforcer,
+  FileAdapter,
   Model,
   newEnforcer,
   newModelFromString,
@@ -19,7 +20,6 @@ import {
 } from 'casbin';
 import * as Knex from 'knex';
 import { MockClient } from 'knex-mock-client';
-import { isEqual } from 'lodash';
 import { Logger } from 'winston';
 
 import {
@@ -136,6 +136,7 @@ describe('RBACPermissionPolicy Tests', () => {
     const enfDelegate = new EnforcerDelegate(
       enf,
       policyMetadataStorageMock,
+      roleMetadataStorageMock,
       knex,
     );
 
@@ -155,12 +156,8 @@ describe('RBACPermissionPolicy Tests', () => {
     let policy: RBACPermissionPolicy;
 
     beforeEach(async () => {
-      const adapter = new StringAdapter(
-        `
-                p, user:default/known_user, test.resource.deny, use, allow
-        `,
-      );
       const csvPermFile = resolve(__dirname, './test/data/rbac-policy.csv');
+      const adapter = new FileAdapter(csvPermFile);
       const config = new ConfigReader({
         permission: {
           rbac: {
@@ -182,6 +179,7 @@ describe('RBACPermissionPolicy Tests', () => {
       const enfDelegate = new EnforcerDelegate(
         enf,
         policyMetadataStorageMock,
+        roleMetadataStorageMock,
         knex,
       );
 
@@ -288,22 +286,6 @@ describe('RBACPermissionPolicy Tests', () => {
       },
     });
 
-    const roleMetadataStorage: RoleMetadataStorage = {
-      findRoleMetadata: jest
-        .fn()
-        .mockImplementation(
-          async (
-            _roleEntityRef: string,
-            _trx: Knex.Knex.Transaction,
-          ): Promise<RoleMetadata> => {
-            return { source: 'csv-file' };
-          },
-        ),
-      createRoleMetadata: jest.fn().mockImplementation(),
-      updateRoleMetadata: jest.fn().mockImplementation(),
-      removeRoleMetadata: jest.fn().mockImplementation(),
-    };
-
     const policyMetadataStorage: PolicyMetadataStorage = {
       findPolicyMetadataBySource: jest.fn().mockImplementation(),
       findPolicyMetadata: jest
@@ -316,7 +298,7 @@ describe('RBACPermissionPolicy Tests', () => {
     };
 
     beforeEach(() => {
-      (roleMetadataStorage.removeRoleMetadata as jest.Mock).mockReset();
+      (roleMetadataStorageMock.removeRoleMetadata as jest.Mock).mockReset();
       (policyMetadataStorage.removePolicyMetadata as jest.Mock).mockReset();
     });
 
@@ -349,6 +331,7 @@ describe('RBACPermissionPolicy Tests', () => {
       const enfDelegate = new EnforcerDelegate(
         enf,
         policyMetadataStorage,
+        roleMetadataStorageMock,
         knex,
       );
 
@@ -359,7 +342,7 @@ describe('RBACPermissionPolicy Tests', () => {
         conf,
         conditionalStorage,
         enfDelegate,
-        roleMetadataStorage,
+        roleMetadataStorageMock,
         knex,
       );
     }
@@ -428,6 +411,7 @@ describe('RBACPermissionPolicy Tests', () => {
         ['role:default/catalog-writer', 'catalog-entity', 'update', 'allow'],
         ['user:default/guest', 'catalog-entity', 'read', 'allow'],
         ['user:default/guest', 'catalog.entity.create', 'use', 'allow'],
+        ['user:default/known_user', 'test.resource.deny', 'use', 'allow'],
       ]);
 
       // policy metadata should to be removed
@@ -445,7 +429,7 @@ describe('RBACPermissionPolicy Tests', () => {
       );
 
       // role metadata should be removed
-      expect(roleMetadataStorage.removeRoleMetadata).toHaveBeenCalledWith(
+      expect(roleMetadataStorageMock.removeRoleMetadata).toHaveBeenCalledWith(
         'role:default/old-role',
         expect.anything(),
       );
@@ -505,6 +489,7 @@ describe('RBACPermissionPolicy Tests', () => {
         ['role:default/catalog-writer', 'catalog-entity', 'update', 'allow'],
         ['user:default/guest', 'catalog-entity', 'read', 'allow'],
         ['user:default/guest', 'catalog.entity.create', 'use', 'allow'],
+        ['user:default/known_user', 'test.resource.deny', 'use', 'allow'],
       ]);
 
       // policy metadata should to be removed
@@ -518,10 +503,9 @@ describe('RBACPermissionPolicy Tests', () => {
       );
 
       // role metadata should not be removed
-      expect(roleMetadataStorage.removeRoleMetadata).not.toHaveBeenCalledWith(
-        'role:default/old-role',
-        expect.anything(),
-      );
+      expect(
+        roleMetadataStorageMock.removeRoleMetadata,
+      ).not.toHaveBeenCalledWith('role:default/old-role', expect.anything());
     });
 
     it('should cleanup old policies and group policies and metadata after re-attach policy file', async () => {
@@ -604,6 +588,7 @@ describe('RBACPermissionPolicy Tests', () => {
         ['role:default/catalog-writer', 'catalog-entity', 'update', 'allow'],
         ['user:default/guest', 'catalog-entity', 'read', 'allow'],
         ['user:default/guest', 'catalog.entity.create', 'use', 'allow'],
+        ['user:default/known_user', 'test.resource.deny', 'use', 'allow'],
       ]);
 
       // policy metadata should to be removed
@@ -633,7 +618,7 @@ describe('RBACPermissionPolicy Tests', () => {
       );
 
       // role metadata should be removed
-      expect(roleMetadataStorage.removeRoleMetadata).toHaveBeenCalledWith(
+      expect(roleMetadataStorageMock.removeRoleMetadata).toHaveBeenCalledWith(
         'role:default/old-role',
         expect.anything(),
       );
@@ -679,19 +664,25 @@ describe('RBACPermissionPolicy Tests', () => {
         storedPolicies,
         storedGroupPolicies,
       );
-      await createRBACPolicy(enf, false);
+      await createRBACPolicy(enf);
 
       expect(await enf.getAllRoles()).toEqual([
-        'role:default/some-role', // stored role
+        'role:default/some-role',
+        'role:default/catalog-writer', // stored role
       ]);
 
       expect(await enf.getGroupingPolicy()).toEqual([
-        ['user:default/tester', 'role:default/some-role'], // stored group policy
+        ['user:default/tester', 'role:default/some-role'],
+        ['user:default/guest', 'role:default/catalog-writer'], // stored group policy
       ]);
 
       expect(await enf.getPolicy()).toEqual([
         // stored policy
         ['role:default/some-role', 'test.some.resource', 'use', 'allow'],
+        ['role:default/catalog-writer', 'catalog-entity', 'update', 'allow'],
+        ['user:default/guest', 'catalog-entity', 'read', 'allow'],
+        ['user:default/guest', 'catalog.entity.create', 'use', 'allow'],
+        ['user:default/known_user', 'test.resource.deny', 'use', 'allow'],
       ]);
 
       // policy metadata should to be removed
@@ -709,7 +700,7 @@ describe('RBACPermissionPolicy Tests', () => {
       );
 
       // role metadata should be removed
-      expect(roleMetadataStorage.removeRoleMetadata).toHaveBeenCalledWith(
+      expect(roleMetadataStorageMock.removeRoleMetadata).toHaveBeenCalledWith(
         'role:default/old-role',
         expect.anything(),
       );
@@ -750,19 +741,25 @@ describe('RBACPermissionPolicy Tests', () => {
         storedPolicies,
         storedGroupPolicies,
       );
-      await createRBACPolicy(enf, false);
+      await createRBACPolicy(enf);
 
       expect(await enf.getAllRoles()).toEqual([
-        'role:default/some-role', // stored role
+        'role:default/some-role',
+        'role:default/catalog-writer', // stored role
       ]);
 
       expect(await enf.getGroupingPolicy()).toEqual([
-        ['user:default/tester', 'role:default/some-role'], // stored group policy
+        ['user:default/tester', 'role:default/some-role'],
+        ['user:default/guest', 'role:default/catalog-writer'], // stored group policy
       ]);
 
       expect(await enf.getPolicy()).toEqual([
         // stored policy
         ['role:default/some-role', 'test.some.resource', 'use', 'allow'],
+        ['role:default/catalog-writer', 'catalog-entity', 'update', 'allow'],
+        ['user:default/guest', 'catalog-entity', 'read', 'allow'],
+        ['user:default/guest', 'catalog.entity.create', 'use', 'allow'],
+        ['user:default/known_user', 'test.resource.deny', 'use', 'allow'],
       ]);
 
       // policy metadata should to be removed
@@ -836,19 +833,25 @@ describe('RBACPermissionPolicy Tests', () => {
         storedPolicies,
         storedGroupPolicies,
       );
-      await createRBACPolicy(enf, false);
+      await createRBACPolicy(enf);
 
       expect(await enf.getAllRoles()).toEqual([
-        'role:default/some-role', // stored role
+        'role:default/some-role',
+        'role:default/catalog-writer', // stored role
       ]);
 
       expect(await enf.getGroupingPolicy()).toEqual([
-        ['user:default/tester', 'role:default/some-role'], // stored group policy
+        ['user:default/tester', 'role:default/some-role'],
+        ['user:default/guest', 'role:default/catalog-writer'], // stored group policy
       ]);
 
       expect(await enf.getPolicy()).toEqual([
         // stored policy
         ['role:default/some-role', 'test.some.resource', 'use', 'allow'],
+        ['role:default/catalog-writer', 'catalog-entity', 'update', 'allow'],
+        ['user:default/guest', 'catalog-entity', 'read', 'allow'],
+        ['user:default/guest', 'catalog.entity.create', 'use', 'allow'],
+        ['user:default/known_user', 'test.resource.deny', 'use', 'allow'],
       ]);
 
       // policy metadata should to be removed
@@ -878,13 +881,12 @@ describe('RBACPermissionPolicy Tests', () => {
       );
 
       // role metadata should be removed
-      expect(roleMetadataStorage.removeRoleMetadata).toHaveBeenCalledWith(
+      expect(roleMetadataStorageMock.removeRoleMetadata).toHaveBeenCalledWith(
         'role:default/old-role',
         expect.anything(),
       );
     });
   });
-
   describe('Policy checks for users', () => {
     let policy: RBACPermissionPolicy;
 
@@ -918,6 +920,7 @@ describe('RBACPermissionPolicy Tests', () => {
       const enfDelegate = new EnforcerDelegate(
         enf,
         policyMetadataStorageMock,
+        roleMetadataStorageMock,
         knex,
       );
 
@@ -1052,6 +1055,181 @@ describe('RBACPermissionPolicy Tests', () => {
       expect(decision.result).toBe(AuthorizeResult.ALLOW);
     });
   });
+
+  describe('Policy checks from config file', () => {
+    let policy: RBACPermissionPolicy;
+    let enfDelegate: EnforcerDelegate;
+    let enf: Enforcer;
+    const roleMetadataStorageTest: RoleMetadataStorage = {
+      findRoleMetadata: jest
+        .fn()
+        .mockImplementation(
+          async (
+            _roleEntityRef: string,
+            _trx: Knex.Knex.Transaction,
+          ): Promise<RoleMetadata> => {
+            return { source: 'legacy' };
+          },
+        ),
+      createRoleMetadata: jest.fn().mockImplementation(),
+      updateRoleMetadata: jest.fn().mockImplementation(),
+      removeRoleMetadata: jest.fn().mockImplementation(),
+    };
+
+    const policyMetadataStorageTest: PolicyMetadataStorage = {
+      findPolicyMetadataBySource: jest
+        .fn()
+        .mockImplementation(
+          async (_source: Source): Promise<PermissionPolicyMetadataDao[]> => {
+            return [];
+          },
+        ),
+      findPolicyMetadata: jest.fn().mockImplementation(),
+      createPolicyMetadata: jest.fn().mockImplementation(),
+      removePolicyMetadata: jest.fn().mockImplementation(),
+    };
+
+    const adminRole = 'role:default/rbac_admin';
+    const groupPolicy = [
+      ['user:default/test_admin', 'role:default/rbac_admin'],
+    ];
+    const permissions = [
+      ['role:default/rbac_admin', 'policy-entity', 'read', 'allow'],
+      ['role:default/rbac_admin', 'policy-entity', 'create', 'allow'],
+      ['role:default/rbac_admin', 'policy-entity', 'delete', 'allow'],
+      ['role:default/rbac_admin', 'policy-entity', 'update', 'allow'],
+    ];
+    const oldGroupPolicy = [
+      'user:default/old_admin',
+      'role:default/rbac_admin',
+    ];
+
+    const adapter = new StringAdapter(
+      `p, user:default/known_user, test-resource, update, allow`,
+    );
+    const admins = new Array<{ name: string }>();
+    admins.push({ name: 'user:default/test_admin' });
+    const config = new ConfigReader({
+      permission: {
+        rbac: {
+          admin: {
+            users: admins,
+          },
+        },
+      },
+    });
+    const theModel = newModelFromString(MODEL);
+    const logger = getVoidLogger();
+
+    const knex = Knex.knex({ client: MockClient });
+    catalogApi.getEntities.mockReturnValue({ items: [] });
+
+    beforeEach(async () => {
+      policyMetadataStorageTest.findPolicyMetadataBySource = jest
+        .fn()
+        .mockImplementation(
+          async (source: Source): Promise<PermissionPolicyMetadataDao[]> => {
+            if (source === 'configuration') {
+              return [
+                {
+                  id: 0,
+                  policy: '[user:default/old_admin, role:default/rbac_admin]',
+                  source: 'configuration',
+                },
+                {
+                  id: 1,
+                  policy: '[user:default/test_admin, role:default/rbac_admin]',
+                  source: 'configuration',
+                },
+              ];
+            }
+            return [];
+          },
+        );
+
+      policyMetadataStorageTest.findPolicyMetadata = jest
+        .fn()
+        .mockImplementation(
+          async (
+            _policy: string[],
+            _trx: Knex.Knex.Transaction,
+          ): Promise<PermissionPolicyMetadata> => {
+            const test: PermissionPolicyMetadata = {
+              source: 'configuration',
+            };
+            return test;
+          },
+        );
+
+      enf = await createEnforcer(theModel, adapter, logger, tokenManagerMock);
+
+      enfDelegate = new EnforcerDelegate(
+        enf,
+        policyMetadataStorageTest,
+        roleMetadataStorageTest,
+        knex,
+      );
+
+      await enfDelegate.addGroupingPolicy(oldGroupPolicy, 'configuration');
+
+      policy = await RBACPermissionPolicy.build(
+        logger,
+        config,
+        conditionalStorage,
+        enfDelegate,
+        roleMetadataStorageTest,
+        knex,
+      );
+    });
+
+    it('should build the admin permissions', async () => {
+      const enfRole = await enfDelegate.getFilteredGroupingPolicy(1, adminRole);
+      const enfPermission = await enfDelegate.getFilteredPolicy(0, adminRole);
+      expect(enfRole).toEqual(groupPolicy);
+      expect(enfPermission).toEqual(permissions);
+    });
+
+    it('should build and update a legacy admin permission', async () => {
+      roleMetadataStorageTest.findRoleMetadata = jest
+        .fn()
+        .mockImplementationOnce(
+          async (
+            _roleEntityRef: string,
+            _trx: Knex.Knex.Transaction,
+          ): Promise<RoleMetadata> => {
+            return { source: 'legacy' };
+          },
+        );
+
+      const enfRole = await enfDelegate.getFilteredGroupingPolicy(1, adminRole);
+      const enfPermission = await enfDelegate.getFilteredPolicy(0, adminRole);
+
+      expect(enfRole).toEqual(groupPolicy);
+      expect(enfPermission).toEqual(permissions);
+      expect(roleMetadataStorageTest.removeRoleMetadata).toHaveBeenCalled();
+      expect(roleMetadataStorageTest.createRoleMetadata).toHaveBeenCalled();
+    });
+
+    it('should allow read access to resource permission for user from config file', async () => {
+      const decision = await policy.handle(
+        newPolicyQueryWithResourcePermission(
+          'policy.entity.read',
+          'policy-entity',
+          'read',
+        ),
+        newIdentityResponse('user:default/test_admin'),
+      );
+      expect(decision.result).toBe(AuthorizeResult.ALLOW);
+    });
+
+    it('should remove users that are no longer in the config file', async () => {
+      const enfRole = await enfDelegate.getFilteredGroupingPolicy(1, adminRole);
+      const enfPermission = await enfDelegate.getFilteredPolicy(0, adminRole);
+      expect(enfRole).toEqual(groupPolicy);
+      expect(enfRole).not.toContain(oldGroupPolicy);
+      expect(enfPermission).toEqual(permissions);
+    });
+  });
 });
 
 describe('Policy checks for users and groups', () => {
@@ -1143,6 +1321,7 @@ describe('Policy checks for users and groups', () => {
     const enfDelegate = new EnforcerDelegate(
       enf,
       policyMetadataStorageMock,
+      roleMetadataStorageMock,
       knex,
     );
 

--- a/plugins/rbac-backend/src/service/permission-policy.ts
+++ b/plugins/rbac-backend/src/service/permission-policy.ts
@@ -16,14 +16,11 @@ import {
 
 import { Enforcer, FileAdapter, newEnforcer, newModelFromString } from 'casbin';
 import { Knex } from 'knex';
-import { isEqual } from 'lodash';
 import { Logger } from 'winston';
-
-import { Source } from '@janus-idp/backstage-plugin-rbac-common';
 
 import { ConditionalStorage } from '../database/conditional-storage';
 import { RoleMetadataStorage } from '../database/role-metadata';
-import { metadataStringToPolicy } from '../helper';
+import { metadataStringToPolicy, removeTheDifference } from '../helper';
 import { EnforcerDelegate } from './enforcer-delegate';
 import { MODEL } from './permission-model';
 import {
@@ -33,78 +30,90 @@ import {
 
 const adminRoleName = 'role:default/rbac_admin';
 
-async function addRoleMetadata(
-  groupPolicy: string[],
-  source: Source,
-  roleMetadataStorage: RoleMetadataStorage,
-  trx: Knex.Transaction,
-) {
-  const entityRef = groupPolicy[1];
-  if (entityRef.startsWith(`role:`)) {
-    const metadata = await roleMetadataStorage.findRoleMetadata(entityRef, trx);
-    if (!metadata) {
-      await roleMetadataStorage.createRoleMetadata({ source }, entityRef, trx);
-    }
-  }
-}
-
 const useAdmins = async (
   admins: Config[],
   enf: EnforcerDelegate,
   roleMetadataStorage: RoleMetadataStorage,
   knex: Knex,
 ) => {
+  let legacy = false;
   const rbacAdminsGroupPolicies: string[][] = [];
-  admins.flatMap(async localConfig => {
+  const groupPoliciesToCompare: string[] = [];
+  const addedGroupPolicies: string[] = [];
+
+  admins.forEach(async localConfig => {
     const entityRef = localConfig.getString('name');
     validateEntityReference(entityRef);
 
     const groupPolicy = [entityRef, adminRoleName];
     if (!(await enf.hasGroupingPolicy(...groupPolicy))) {
       rbacAdminsGroupPolicies.push(groupPolicy);
+      addedGroupPolicies.push(entityRef);
     }
   });
 
-  const trx = await knex.transaction();
-  try {
-    const adminRoleMeta = await roleMetadataStorage.findRoleMetadata(
-      adminRoleName,
-      trx,
-    );
-    if (!adminRoleMeta) {
+  const adminRoleMeta =
+    await roleMetadataStorage.findRoleMetadata(adminRoleName);
+
+  if (adminRoleMeta?.source === 'legacy') {
+    const trx = await knex.transaction();
+    try {
+      await roleMetadataStorage.removeRoleMetadata(adminRoleName, trx);
+      await trx.commit();
+      legacy = true;
+    } catch (error) {
+      await trx.rollback(error);
+    }
+  }
+
+  if (!adminRoleMeta || legacy) {
+    const trx = await knex.transaction();
+    try {
       await roleMetadataStorage.createRoleMetadata(
         { source: 'configuration' },
         adminRoleName,
         trx,
       );
+      await trx.commit();
+    } catch (error) {
+      await trx.rollback(error);
     }
-
-    // Cannot to save policy with help of addGroupingPolicies, the adapter does not implement the BatchAdapter
-    // if (rbacAdminsGroupPolicies.length > 0) {
-    //   await enf.addGroupingPolicies(rbacAdminsGroupPolicies, 'configuration', trx);
-    // }
-    for (const gPolicy of rbacAdminsGroupPolicies) {
-      await enf.addGroupingPolicy(gPolicy, 'configuration', trx);
-    }
-    await trx.commit();
-  } catch (err) {
-    await trx.rollback(err);
-    throw err;
   }
+
+  await enf.addOrUpdateGroupingPolicies(
+    rbacAdminsGroupPolicies,
+    'configuration',
+    false,
+  );
+
+  const configPoliciesMetadata =
+    await enf.getFilteredPolicyMetadata('configuration');
+
+  for (const policyMetadata of configPoliciesMetadata) {
+    if (metadataStringToPolicy(policyMetadata.policy).length === 2) {
+      const stringPolicy = metadataStringToPolicy(policyMetadata.policy);
+      groupPoliciesToCompare.push(stringPolicy.at(0)!);
+    }
+  }
+
+  await removeTheDifference(
+    groupPoliciesToCompare,
+    addedGroupPolicies,
+    'configuration',
+    adminRoleName,
+    enf,
+  );
 
   const adminReadPermission = [adminRoleName, 'policy-entity', 'read', 'allow'];
-  if (!(await enf.hasPolicy(...adminReadPermission))) {
-    await enf.addPolicy(adminReadPermission, 'configuration');
-  }
+  await enf.addOrUpdatePolicy(adminReadPermission, 'configuration', false);
+
   const adminCreatePermission = [
     adminRoleName,
     'policy-entity',
     'create',
     'allow',
   ];
-  if (!(await enf.hasPolicy(...adminCreatePermission))) {
-    await enf.addPolicy(adminCreatePermission, 'configuration');
-  }
+  await enf.addOrUpdatePolicy(adminCreatePermission, 'configuration', false);
 
   const adminDeletePermission = [
     adminRoleName,
@@ -112,9 +121,7 @@ const useAdmins = async (
     'delete',
     'allow',
   ];
-  if (!(await enf.hasPolicy(...adminDeletePermission))) {
-    await enf.addPolicy(adminDeletePermission, 'configuration');
-  }
+  await enf.addOrUpdatePolicy(adminDeletePermission, 'configuration', false);
 
   const adminUpdatePermission = [
     adminRoleName,
@@ -122,75 +129,42 @@ const useAdmins = async (
     'update',
     'allow',
   ];
-  if (!(await enf.hasPolicy(...adminUpdatePermission))) {
-    await enf.addPolicy(adminUpdatePermission, 'configuration');
-  }
+  await enf.addOrUpdatePolicy(adminUpdatePermission, 'configuration', false);
 };
 
 const removedOldPermissionPoliciesFileData = async (
   enf: EnforcerDelegate,
-  roleMetadataStorage: RoleMetadataStorage,
-  knex: Knex,
   fileEnf?: Enforcer,
-): Promise<void> => {
-  let policiesToDelete: string[][] = [];
-  let groupPoliciesToDelete: string[][] = [];
-
+) => {
+  const tempEnforcer =
+    fileEnf || (await newEnforcer(newModelFromString(MODEL)));
+  const oldFilePolicies = new Set<string[]>();
   const policiesMetadata = await enf.getFilteredPolicyMetadata('csv-file');
   for (const policyMetadata of policiesMetadata) {
-    const policy = metadataStringToPolicy(policyMetadata.policy);
-    if (policy.length === 2) {
-      groupPoliciesToDelete.push(policy);
-    } else {
-      policiesToDelete.push(policy);
+    oldFilePolicies.add(metadataStringToPolicy(policyMetadata.policy));
+  }
+
+  const policiesToDelete: string[][] = [];
+  const groupPoliciesToDelete: string[][] = [];
+  for (const oldFilePolicy of oldFilePolicies) {
+    if (
+      oldFilePolicy.length === 2 &&
+      !(await tempEnforcer.hasGroupingPolicy(...oldFilePolicy))
+    ) {
+      groupPoliciesToDelete.push(oldFilePolicy);
+    } else if (
+      oldFilePolicy.length > 2 &&
+      !(await tempEnforcer.hasPolicy(...oldFilePolicy))
+    ) {
+      policiesToDelete.push(oldFilePolicy);
     }
   }
 
-  let rolesToDelete = new Set(
-    groupPoliciesToDelete
-      .filter(gp => gp[1].startsWith('role:'))
-      .map(gp => gp[1]),
-  );
-
-  if (fileEnf) {
-    groupPoliciesToDelete = await groupPoliciesToDelete.filter(
-      async gp => !(await fileEnf.hasGroupingPolicy(...gp)),
-    );
-    policiesToDelete = await policiesToDelete.filter(
-      async p => !(await fileEnf.hasPolicy(...p)),
-    );
-
-    const actualFileRoles = await fileEnf.getAllRoles();
-    rolesToDelete = new Set(
-      Array.from(rolesToDelete).filter(
-        role => !actualFileRoles.some(actualRole => isEqual(actualRole, role)),
-      ),
-    );
+  if (groupPoliciesToDelete.length > 0) {
+    await enf.removeGroupingPolicies(groupPoliciesToDelete, 'csv-file', true);
   }
-
-  const trx = await knex.transaction();
-  try {
-    if (groupPoliciesToDelete.length > 0) {
-      await enf.removeGroupingPolicies(groupPoliciesToDelete, true, trx);
-    }
-    if (policiesToDelete.length > 0) {
-      await enf.removePolicies(policiesToDelete, true, trx);
-    }
-    for (const roleMeta of rolesToDelete) {
-      const isRoleUnUsed =
-        (await enf.getFilteredGroupingPolicy(1, ...[roleMeta])).length === 0;
-
-      if (
-        (await roleMetadataStorage.findRoleMetadata(roleMeta)) &&
-        isRoleUnUsed
-      ) {
-        await roleMetadataStorage.removeRoleMetadata(roleMeta, trx);
-      }
-    }
-    await trx.commit();
-  } catch (err) {
-    await trx.rollback(err);
-    throw err;
+  if (policiesToDelete.length > 0) {
+    await enf.removePolicies(policiesToDelete, 'csv-file', true);
   }
 };
 
@@ -198,7 +172,6 @@ const addPermissionPoliciesFileData = async (
   preDefinedPoliciesFile: string,
   enf: EnforcerDelegate,
   roleMetadataStorage: RoleMetadataStorage,
-  knex: Knex,
 ) => {
   const fileEnf = await newEnforcer(
     newModelFromString(MODEL),
@@ -214,36 +187,14 @@ const addPermissionPoliciesFileData = async (
     roleMetadataStorage,
   );
 
-  await removedOldPermissionPoliciesFileData(
-    enf,
-    roleMetadataStorage,
-    knex,
-    fileEnf,
-  );
+  await removedOldPermissionPoliciesFileData(enf, fileEnf);
 
   for (const policy of policies) {
-    if (!(await enf.hasPolicy(...policy))) {
-      await enf.addPolicy(policy, 'csv-file');
-    }
+    await enf.addOrUpdatePolicy(policy, 'csv-file', true);
   }
 
   for (const groupPolicy of groupPolicies) {
-    if (!(await enf.hasGroupingPolicy(...groupPolicy))) {
-      const trx = await knex.transaction();
-      try {
-        await addRoleMetadata(
-          groupPolicy,
-          'csv-file',
-          roleMetadataStorage,
-          trx,
-        );
-        await enf.addGroupingPolicy(groupPolicy, 'csv-file', trx);
-        await trx.commit();
-      } catch (err) {
-        await trx.rollback(err);
-        throw err;
-      }
-    }
+    await enf.addOrUpdateGroupingPolicy(groupPolicy, 'csv-file', false);
   }
 };
 
@@ -273,14 +224,9 @@ export class RBACPermissionPolicy implements PermissionPolicy {
         policiesFile,
         enforcerDelegate,
         roleMetadataStorage,
-        knex,
       );
     } else {
-      await removedOldPermissionPoliciesFileData(
-        enforcerDelegate,
-        roleMetadataStorage,
-        knex,
-      );
+      await removedOldPermissionPoliciesFileData(enforcerDelegate);
     }
 
     if (adminUsers) {

--- a/plugins/rbac-backend/src/service/policy-builder.ts
+++ b/plugins/rbac-backend/src/service/policy-builder.ts
@@ -89,6 +89,7 @@ export class PolicyBuilder {
     const enforcerDelegate = new EnforcerDelegate(
       enf,
       policyMetadataStorage,
+      roleMetadataStorage,
       knex,
     );
 
@@ -131,7 +132,6 @@ export class PolicyBuilder {
       conditionStorage,
       pluginIdProvider,
       roleMetadataStorage,
-      knex,
     );
     return server.serve();
   }

--- a/plugins/rbac-backend/src/service/test/data/rbac-policy.csv
+++ b/plugins/rbac-backend/src/service/test/data/rbac-policy.csv
@@ -4,3 +4,5 @@ g, user:default/guest, role:default/catalog-writer
 p, role:default/catalog-writer, catalog-entity, update, allow
 p, user:default/guest, catalog-entity, read, allow
 p, user:default/guest, catalog.entity.create, use, allow
+
+p, user:default/known_user, test.resource.deny, use, allow


### PR DESCRIPTION
Here is the ability to update legacy policies for your review.

A couple of quick notes,

- I still need to retest this manually to ensure it still works like it is suppose to
  - Test with database will legacy policies update (csv, config, rest)
  - Test without database will everything load and run appropriately
- Update this PR whenever you rebase to fix the merge conflict
  - I will probably end up having to close this and recreate another PR with the updates

I tried to keep the changes to a minimum as much as possible, but I did rewrite some of your code when working on this. If there is something that you do not agree with, let me know and I will revert and find another way of handling the issue.