### PR TITLE
fix(rbac): fix migration issue with multiple admins

### DIFF
--- a/plugins/rbac-backend/migrations/20231221113214_migrations.js
+++ b/plugins/rbac-backend/migrations/20231221113214_migrations.js
@@ -13,9 +13,18 @@ exports.up = async function up(knex) {
       .where('ptype', 'g')
       .then(listGroupPolicies => {
         const allGroupPolicies = [];
+        let rbacFlag = false;
         for (const groupPolicy of listGroupPolicies) {
           const { v1 } = groupPolicy;
+          console.log(`here is v1 ${v1}`);
+          if (v1 === 'role:default/rbac_admin') {
+            rbacFlag = true;
+            continue;
+          }
           allGroupPolicies.push(v1);
+        }
+        if (rbacFlag) {
+          allGroupPolicies.push('role:default/rbac_admin');
         }
         return allGroupPolicies;
       });

--- a/plugins/rbac-backend/migrations/20231221113214_migrations.js
+++ b/plugins/rbac-backend/migrations/20231221113214_migrations.js
@@ -16,7 +16,6 @@ exports.up = async function up(knex) {
         let rbacFlag = false;
         for (const groupPolicy of listGroupPolicies) {
           const { v1 } = groupPolicy;
-          console.log(`here is v1 ${v1}`);
           if (v1 === 'role:default/rbac_admin') {
             rbacFlag = true;
             continue;


### PR DESCRIPTION
Missed this commit, sorry. 

There is an issue whenever there are multiple rbac admins present before the migration script is executed. What ends up happening is that the script will attempt to insert each of the `role:default/rbac_admin` into the database, which throws an error since there is already one present after the first attempt. 